### PR TITLE
fix/SSAD-0003/config_file_v3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,41 +21,48 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: "17"
-          distribution: "adopt"
+          distribution: "temurin"
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 8.0.x
 
+      - name: Install SonarScanner
+        run: dotnet tool install --global dotnet-sonarscanner
+
       - name: Restore Dependencies
         run: dotnet restore ./Streetcode/Streetcode.sln
 
-      - name: Install xmldocmd
-        run: dotnet tool install xmldocmd -g
+      - name: SonarScanner Begin
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: |
+          dotnet sonarscanner begin /k:"project-studying-dotnet_Streetcode-Server-January-2026" /o:"project-studying-dotnet" `
+            /d:sonar.token="$env:SONAR_TOKEN" `
+            /d:sonar.host.url="https://sonarcloud.io" `
+            /d:sonar.cs.opencover.reportsPaths="**/coverage.xml" `
+            /d:sonar.exclusions="**/bin/**,**/obj/**,**/Migrations/**" `
+            /d:sonar.coverage.exclusions="**/*Tests.cs,**/*Test.cs"
 
       - name: Build
         run: dotnet build ./Streetcode/Streetcode.sln --configuration Release --no-restore
 
-      - name: Install coverlet.console
-        run: dotnet tool install -g coverlet.console
-
       - name: Test and Code Coverage
         run: |
-          dotnet test ./Streetcode/Streetcode.XUnitTest/Streetcode.XUnitTest.csproj --configuration Release --no-build --verbosity normal --collect:"XPlat Code Coverage" --results-directory ./coverage /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:CoverletOutput=./coverage/coverage.xml
+          dotnet test ./Streetcode/Streetcode.XUnitTest/Streetcode.XUnitTest.csproj `
+            --configuration Release `
+            --no-build `
+            /p:CollectCoverage=true `
+            /p:CoverletOutput=./coverage/coverage.xml `
+            /p:CoverletOutputFormat=opencover
 
-      - name: Install SonarScanner
-        run: dotnet tool install --global dotnet-sonarscanner
-
-      - name: Set SonarCloud Token
-        run: echo "SONAR_TOKEN=${{ secrets.SONAR_TOKEN }}" >> $GITHUB_ENV
-
-      - name: SonarScanner Analysis
-        id: sonar
-        run: |
-          dotnet sonarscanner begin /k:"project-studying-dotnet_Streetcode-Server-January-2026" /o:"project-studying-dotnet" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.opencover.reportPaths="./coverage/coverage.xml"
-          dotnet build ./Streetcode/Streetcode.sln --configuration Release
-          dotnet sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
+      - name: SonarScanner End
+        if: always()
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: dotnet sonarscanner end /d:sonar.token="$env:SONAR_TOKEN"
 
       - name: Publish Code Coverage Report
         if: always()


### PR DESCRIPTION
Updated the build.yml workflow:
- reorganized steps to follow the recommended sequence;
- removed the duplicate 'dotnet build' command that was previously running inside the analysis step;
- added 'sonar.exclusions' for migrations and 'sonar.coverage.exclusions' for test files;
- removed unused tools (xmldocmd, coverlet.console) and the redundant 'Set SonarCloud Token' step;
- switched to passing tokens via $env variables;
- updated Java distribution from adopt to temurin (current standard).