### PR TITLE
Feat/SSAD-0088/auto_remove_expired_tokens

### DIFF
--- a/Streetcode/Streetcode.Auth.BLL/Interfaces/ITokenService.cs
+++ b/Streetcode/Streetcode.Auth.BLL/Interfaces/ITokenService.cs
@@ -8,5 +8,6 @@ namespace Streetcode.Auth.BLL.Interfaces
         Task<(string AccessToken, RefreshToken RefreshToken)> RotateRefreshTokenAsync(string oldRefreshToken);
         Task RevokeRefreshTokenAsync(string token);
         Task RevokeAllAsync(string userId);
+        Task RemoveExpiredRefreshTokensAsync();
     }
 }

--- a/Streetcode/Streetcode.Auth.BLL/Services/TokenService.cs
+++ b/Streetcode/Streetcode.Auth.BLL/Services/TokenService.cs
@@ -2,9 +2,8 @@
 using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Text;
-using MassTransit;
 using Microsoft.AspNetCore.Identity;
-using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
 using Streetcode.Auth.BLL.DTO.Options;
@@ -20,15 +19,18 @@ namespace Streetcode.Auth.BLL.Services
         private readonly JwtOptionsDTO _jwtOptions;
         private readonly UserManager<ApplicationUser> _userManager;
         private readonly IRefreshTokenRepository _refreshTokenRepository;
+        private readonly ILogger<TokenService> _logger;
 
         public TokenService(
             IOptions<JwtOptionsDTO> jwtOptions,
             UserManager<ApplicationUser> userManager,
-            IRefreshTokenRepository refreshTokenRepository)
+            IRefreshTokenRepository refreshTokenRepository,
+            ILogger<TokenService> logger)
         {
             _jwtOptions = jwtOptions.Value;
             _userManager = userManager;
             _refreshTokenRepository = refreshTokenRepository;
+            _logger = logger;
         }
 
         public async Task<(string AccessToken, RefreshToken RefreshToken)> GenerateTokensAsync(ApplicationUser user)
@@ -80,6 +82,15 @@ namespace Streetcode.Auth.BLL.Services
         public async Task RevokeAllAsync(string userId)
         {
             await _refreshTokenRepository.RevokeAllAsync(userId);
+        }
+
+        public async Task RemoveExpiredRefreshTokensAsync()
+        {
+            var deletedCount = await _refreshTokenRepository.DeleteExpiredAsync();
+
+            _logger.LogInformation(
+                "Refresh tokens cleanup completed. DeletedCount={DeletedCount}",
+                deletedCount);
         }
 
         private async Task<string> GenerateAccessToken(ApplicationUser user)

--- a/Streetcode/Streetcode.Auth.DAL/Repositories/Interfaces/IRefreshTokenRepository.cs
+++ b/Streetcode/Streetcode.Auth.DAL/Repositories/Interfaces/IRefreshTokenRepository.cs
@@ -9,6 +9,6 @@ namespace Streetcode.Auth.DAL.Repositories.Interfaces
         Task UpdateAsync(RefreshToken refreshToken);
         Task RevokeAllAsync(string userId);
         Task DeleteAsync(RefreshToken refreshToken);
-        Task DeleteExpiredAsync();
+        Task<int> DeleteExpiredAsync();
     }
 }

--- a/Streetcode/Streetcode.Auth.DAL/Repositories/Realizations/RefreshTokenRepository.cs
+++ b/Streetcode/Streetcode.Auth.DAL/Repositories/Realizations/RefreshTokenRepository.cs
@@ -57,12 +57,11 @@ namespace Streetcode.Auth.DAL.Repositories.Realizations
             await _context.SaveChangesAsync();
         }
 
-        public async Task DeleteExpiredAsync()
+        public async Task<int> DeleteExpiredAsync()
         {
-            await _context.RefreshTokens
+            return await _context.RefreshTokens
                 .Where(t => t.Expires < DateTime.UtcNow)
                 .ExecuteDeleteAsync();
-            await _context.SaveChangesAsync();
         }
     }
 }

--- a/Streetcode/Streetcode.Auth.WebApi/Extensions/ServiceCollectionExtensions.cs
+++ b/Streetcode/Streetcode.Auth.WebApi/Extensions/ServiceCollectionExtensions.cs
@@ -181,10 +181,7 @@ public static class ServiceCollectionExtensions
 
         services.AddHangfire(config =>
         {
-            config.SetDataCompatibilityLevel(CompatibilityLevel.Version_180)
-                  .UseSimpleAssemblyNameTypeSerializer()
-                  .UseRecommendedSerializerSettings()
-                  .UseSqlServerStorage(connectionString);
+            config.UseSqlServerStorage(connectionString);
         });
 
         services.AddHangfireServer();

--- a/Streetcode/Streetcode.Auth.WebApi/Extensions/ServiceCollectionExtensions.cs
+++ b/Streetcode/Streetcode.Auth.WebApi/Extensions/ServiceCollectionExtensions.cs
@@ -18,6 +18,8 @@ using Streetcode.Auth.DAL.Repositories.Interfaces;
 using Streetcode.Auth.DAL.Repositories.Realizations;
 using Streetcode.Auth.WebApi.Services.Interfaces;
 using Streetcode.Auth.WebApi.Services.Realizations;
+using Hangfire;
+using Hangfire.SqlServer;
 
 namespace Streetcode.Auth.WebApi.Extensions;
 
@@ -171,5 +173,20 @@ public static class ServiceCollectionExtensions
                 }
             });
         });
+    }
+
+    public static void AddHangfireServices(this IServiceCollection services, IConfiguration configuration)
+    {
+        var connectionString = configuration.GetConnectionString("DefaultConnection");
+
+        services.AddHangfire(config =>
+        {
+            config.SetDataCompatibilityLevel(CompatibilityLevel.Version_180)
+                  .UseSimpleAssemblyNameTypeSerializer()
+                  .UseRecommendedSerializerSettings()
+                  .UseSqlServerStorage(connectionString);
+        });
+
+        services.AddHangfireServer();
     }
 }

--- a/Streetcode/Streetcode.Auth.WebApi/Program.cs
+++ b/Streetcode/Streetcode.Auth.WebApi/Program.cs
@@ -1,3 +1,5 @@
+using Hangfire;
+using Streetcode.Auth.BLL.Interfaces;
 using Streetcode.Auth.WebApi.Extensions;
 using Streetcode.Auth.WebApi.Middlewares;
 
@@ -9,6 +11,7 @@ builder.Services.AddDataAccessServices(builder.Configuration);
 builder.Services.AddIdentityServices(builder.Configuration);
 builder.Services.AddCustomServices(builder.Configuration);
 builder.Services.AddCorsServices(builder.Configuration);
+builder.Services.AddHangfireServices(builder.Configuration);
 builder.Services.AddSwaggerServices();
 
 var app = builder.Build();
@@ -32,10 +35,17 @@ app.UseCors("CorsPolicy");
 app.UseAuthentication();
 app.UseAuthorization();
 
+app.UseHangfireDashboard("/dash");
+
 app.MapControllers();
 
 await app.ApplyMigrationsAsync();
 
 await app.ApplySeedingAsync();
+
+RecurringJob.AddOrUpdate<ITokenService>(
+    "delete-expired-refresh-tokens",
+    service => service.RemoveExpiredRefreshTokensAsync(),
+    Cron.Daily);
 
 app.Run();

--- a/Streetcode/Streetcode.Auth.WebApi/Streetcode.Auth.WebApi.csproj
+++ b/Streetcode/Streetcode.Auth.WebApi/Streetcode.Auth.WebApi.csproj
@@ -9,6 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.1" />
+    <PackageReference Include="Hangfire.AspNetCore" Version="1.8.23" />
+    <PackageReference Include="Hangfire.SqlServer" Version="1.8.23" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.23" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.23" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.23">


### PR DESCRIPTION
## Implemented automatic background cleanup for expired refresh tokens using Hangfire

Refresh token logic was implemented in a closed PR #75  (auth microservice).
This PR focuses on "Auto remove expired tokens" requirement by introducing a background cleanup job.

Closes #88 