### PR TITLE
Feat/ssad 0111/admin reviewing comments and replies

### DIFF
--- a/Streetcode/Streetcode.BLL/DTO/Streetcode/Comments/CommentDTO.cs
+++ b/Streetcode/Streetcode.BLL/DTO/Streetcode/Comments/CommentDTO.cs
@@ -9,5 +9,7 @@
         public int StreetcodeId { get; set; }
         public string UserId { get; set; }
         public string UserFullName { get; set; }
+        public int? ParentId { get; set; }
+        public List<CommentDTO> Replies { get; set; } = new();
     }
 }

--- a/Streetcode/Streetcode.BLL/DTO/Streetcode/Comments/CreateCommentDTO.cs
+++ b/Streetcode/Streetcode.BLL/DTO/Streetcode/Comments/CreateCommentDTO.cs
@@ -5,5 +5,7 @@
         public string TextContent { get; set; }
 
         public int StreetcodeId { get; set; }
+
+        public int? ParentId { get; set; }
     }
 }

--- a/Streetcode/Streetcode.BLL/DTO/Streetcode/Comments/UpdateCommentStatusDTO.cs
+++ b/Streetcode/Streetcode.BLL/DTO/Streetcode/Comments/UpdateCommentStatusDTO.cs
@@ -1,0 +1,10 @@
+﻿using Streetcode.DAL.Enums;
+
+namespace Streetcode.BLL.DTO.Streetcode.Comments
+{
+    public class UpdateCommentStatusDTO
+    {
+        public int Id { get; set; }
+        public CommentStatus Status { get; set; }
+    }
+}

--- a/Streetcode/Streetcode.BLL/Mapping/Streetcode/Comments/CommentProfile.cs
+++ b/Streetcode/Streetcode.BLL/Mapping/Streetcode/Comments/CommentProfile.cs
@@ -16,7 +16,10 @@ namespace Streetcode.BLL.Mapping.Streetcode.Comments
             CreateMap<UpdateCommentDTO, Comment>()
                 .ForMember(dest => dest.UserId, opt => opt.Ignore())
                 .ForMember(dest => dest.StreetcodeId, opt => opt.Ignore())
-                .ForMember(dest => dest.CreatedAt, opt => opt.Ignore());
+                .ForMember(dest => dest.CreatedAt, opt => opt.Ignore())
+                .ForMember(dest => dest.ParentId, opt => opt.Ignore())
+                .ForMember(dest => dest.Replies, opt => opt.Ignore())
+                .ForMember(dest => dest.Status, opt => opt.Ignore());
         }
     }
 }

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Comments/AdminDelete/AdminDeleteCommentCommand.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Comments/AdminDelete/AdminDeleteCommentCommand.cs
@@ -1,0 +1,7 @@
+﻿using FluentResults;
+using MediatR;
+
+namespace Streetcode.BLL.MediatR.Streetcode.Comments.AdminDelete
+{
+    public record AdminDeleteCommentCommand(int Id) : IRequest<Result<Unit>>;
+}

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Comments/AdminDelete/AdminDeleteCommentCommandValidator.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Comments/AdminDelete/AdminDeleteCommentCommandValidator.cs
@@ -1,0 +1,16 @@
+﻿using FluentValidation;
+using Streetcode.Resources;
+using Streetcode.Shared.Extensions;
+
+namespace Streetcode.BLL.MediatR.Streetcode.Comments.AdminDelete
+{
+    public class AdminDeleteCommentCommandValidator : AbstractValidator<AdminDeleteCommentCommand>
+    {
+        public AdminDeleteCommentCommandValidator()
+        {
+            RuleFor(x => x.Id)
+                .GreaterThan(0)
+                .WithMessage(Messages.Error_PropertyMustBeGreaterThanZero.Format(nameof(AdminDeleteCommentCommand.Id)));
+        }
+    }
+}

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Comments/AdminDelete/AdminDeleteCommentHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Comments/AdminDelete/AdminDeleteCommentHandler.cs
@@ -21,10 +21,10 @@ namespace Streetcode.BLL.MediatR.Streetcode.Comments.AdminDelete
 
         public async Task<Result<Unit>> Handle(AdminDeleteCommentCommand request, CancellationToken cancellationToken)
         {
-            var targetComment = await _repositoryWrapper.CommentRepository
+            var comment = await _repositoryWrapper.CommentRepository
                 .GetFirstOrDefaultAsync(t => t.Id == request.Id);
 
-            if (targetComment is null)
+            if (comment is null)
             {
                 var errorNotFoundMsg = Messages.Error_EntityWithIdNotFound.Format(nameof(Comment), request.Id);
                 _logger.LogError(request, errorNotFoundMsg);
@@ -32,37 +32,37 @@ namespace Streetcode.BLL.MediatR.Streetcode.Comments.AdminDelete
             }
 
             var allComments = await _repositoryWrapper.CommentRepository
-                .GetAllAsync(c => c.StreetcodeId == targetComment.StreetcodeId);
+                .GetAllAsync(c => c.StreetcodeId == comment.StreetcodeId);
 
-            var childrenLookup = allComments
+            var commentLookup = allComments
                 .Where(c => c.ParentId.HasValue)
                 .GroupBy(c => c.ParentId.Value)
                 .ToDictionary(g => g.Key, g => g.ToList());
 
             var commentsToDelete = new List<Comment>();
-            var stack = new Stack<Comment>();
+            var commentsStack = new Stack<Comment>();
 
-            stack.Push(targetComment);
+            commentsStack.Push(comment);
 
-            while (stack.Count > 0)
+            while (commentsStack.Count > 0)
             {
-                var current = stack.Pop();
+                var current = commentsStack.Pop();
                 commentsToDelete.Add(current);
 
-                if (childrenLookup.TryGetValue(current.Id, out var children))
+                if (commentLookup.TryGetValue(current.Id, out var children))
                 {
                     foreach (var child in children)
                     {
-                        stack.Push(child);
+                        commentsStack.Push(child);
                     }
                 }
             }
 
             _repositoryWrapper.CommentRepository.DeleteRange(commentsToDelete);
 
-            var successSave = await _repositoryWrapper.SaveChangesAsync() > 0;
+            var success = await _repositoryWrapper.SaveChangesAsync() > 0;
 
-            if (successSave)
+            if (success)
             {
                 return Result.Ok(Unit.Value);
             }

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Comments/AdminDelete/AdminDeleteCommentHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Comments/AdminDelete/AdminDeleteCommentHandler.cs
@@ -1,0 +1,75 @@
+﻿using FluentResults;
+using MediatR;
+using Streetcode.BLL.Interfaces.Logging;
+using Streetcode.DAL.Entities.Streetcode.Comments;
+using Streetcode.DAL.Repositories.Interfaces.Base;
+using Streetcode.Resources;
+using Streetcode.Shared.Extensions;
+
+namespace Streetcode.BLL.MediatR.Streetcode.Comments.AdminDelete
+{
+    public class AdminDeleteCommentHandler : IRequestHandler<AdminDeleteCommentCommand, Result<Unit>>
+    {
+        private readonly IRepositoryWrapper _repositoryWrapper;
+        private readonly ILoggerService _logger;
+
+        public AdminDeleteCommentHandler(IRepositoryWrapper repositoryWrapper, ILoggerService logger)
+        {
+            _repositoryWrapper = repositoryWrapper;
+            _logger = logger;
+        }
+
+        public async Task<Result<Unit>> Handle(AdminDeleteCommentCommand request, CancellationToken cancellationToken)
+        {
+            var targetComment = await _repositoryWrapper.CommentRepository
+                .GetFirstOrDefaultAsync(t => t.Id == request.Id);
+
+            if (targetComment is null)
+            {
+                var errorNotFoundMsg = Messages.Error_EntityWithIdNotFound.Format(nameof(Comment), request.Id);
+                _logger.LogError(request, errorNotFoundMsg);
+                return Result.Fail(new Error(errorNotFoundMsg));
+            }
+
+            var allComments = await _repositoryWrapper.CommentRepository
+                .GetAllAsync(c => c.StreetcodeId == targetComment.StreetcodeId);
+
+            var childrenLookup = allComments
+                .Where(c => c.ParentId.HasValue)
+                .GroupBy(c => c.ParentId.Value)
+                .ToDictionary(g => g.Key, g => g.ToList());
+
+            var commentsToDelete = new List<Comment>();
+            var stack = new Stack<Comment>();
+
+            stack.Push(targetComment);
+
+            while (stack.Count > 0)
+            {
+                var current = stack.Pop();
+                commentsToDelete.Add(current);
+
+                if (childrenLookup.TryGetValue(current.Id, out var children))
+                {
+                    foreach (var child in children)
+                    {
+                        stack.Push(child);
+                    }
+                }
+            }
+
+            _repositoryWrapper.CommentRepository.DeleteRange(commentsToDelete);
+
+            var successSave = await _repositoryWrapper.SaveChangesAsync() > 0;
+
+            if (successSave)
+            {
+                return Result.Ok(Unit.Value);
+            }
+
+            var errorMsg = Messages.Error_FailedToDeleteEntity.Format(nameof(Comment));
+            _logger.LogError(request, errorMsg);
+            return Result.Fail(new Error(errorMsg));
+        }
+    }
+}

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Comments/Create/CreateCommentHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Comments/Create/CreateCommentHandler.cs
@@ -25,6 +25,18 @@ namespace Streetcode.BLL.MediatR.Streetcode.Comments.Create
 
         public async Task<Result<CommentDTO>> Handle(CreateCommentCommand command, CancellationToken cancellationToken)
         {
+            if (command.Comment.ParentId.HasValue)
+            {
+                var parentComment = await _repositoryWrapper.CommentRepository
+                    .GetFirstOrDefaultAsync(c => c.Id == command.Comment.ParentId);
+
+                if (parentComment is null)
+                {
+                    var errorMesage = Messages.Error_EntityWithIdNotFound.Format(nameof(Comment), command.Comment.ParentId);
+                    return Result.Fail(new Error(errorMesage));
+                }
+            }
+
             var comment = _mapper.Map<Comment>(command.Comment);
 
             comment.UserId = command.UserId;

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Comments/Delete/DeleteCommentHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Comments/Delete/DeleteCommentHandler.cs
@@ -21,26 +21,51 @@ namespace Streetcode.BLL.MediatR.Streetcode.Comments.Delete
 
         public async Task<Result<Unit>> Handle(DeleteCommentCommand command, CancellationToken cancellationToken)
         {
-            var comment = await _repositoryWrapper.CommentRepository
+            var targetComment = await _repositoryWrapper.CommentRepository
                 .GetFirstOrDefaultAsync(t => t.Id == command.Id);
 
-            if (comment is null)
+            if (targetComment is null)
             {
-                var errorNotFoundMsg = Messages.Error_EntityWithIdNotFound.Format(
-                    nameof(Comment), command.Id);
-
+                var errorNotFoundMsg = Messages.Error_EntityWithIdNotFound.Format(nameof(Comment), command.Id);
                 _logger.LogError(command, errorNotFoundMsg);
                 return Result.Fail(new Error(errorNotFoundMsg));
             }
 
-            if (comment.UserId != command.UserId)
+            if (targetComment.UserId != command.UserId)
             {
                 var errorAuthMsg = Messages.Error_UserNotCommentOwner;
                 _logger.LogError(command, errorAuthMsg);
                 return Result.Fail(new Error(errorAuthMsg));
             }
 
-            _repositoryWrapper.CommentRepository.Delete(comment);
+            var allComments = await _repositoryWrapper.CommentRepository
+                .GetAllAsync(c => c.StreetcodeId == targetComment.StreetcodeId);
+
+            var childrenLookup = allComments
+                .Where(c => c.ParentId.HasValue)
+                .GroupBy(c => c.ParentId.Value)
+                .ToDictionary(g => g.Key, g => g.ToList());
+
+            var commentsToDelete = new List<Comment>();
+            var stack = new Stack<Comment>();
+
+            stack.Push(targetComment);
+
+            while (stack.Count > 0)
+            {
+                var current = stack.Pop();
+                commentsToDelete.Add(current);
+
+                if (childrenLookup.TryGetValue(current.Id, out var children))
+                {
+                    foreach (var child in children)
+                    {
+                        stack.Push(child);
+                    }
+                }
+            }
+
+            _repositoryWrapper.CommentRepository.DeleteRange(commentsToDelete);
 
             var successSave = await _repositoryWrapper.SaveChangesAsync() > 0;
 

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Comments/GetByIdWithReplies/GetCommentByIdWithRepliesHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Comments/GetByIdWithReplies/GetCommentByIdWithRepliesHandler.cs
@@ -53,6 +53,7 @@ namespace Streetcode.BLL.MediatR.Streetcode.Comments.GetByIdWithReplies
 
             var resultComment = dictionary[request.Id];
 
+            resultComment.Replies = resultComment.Replies.OrderBy(c => c.CreatedAt).ToList();
             SortReplies(resultComment.Replies);
 
             return Result.Ok(resultComment);

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Comments/GetByIdWithReplies/GetCommentByIdWithRepliesHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Comments/GetByIdWithReplies/GetCommentByIdWithRepliesHandler.cs
@@ -1,0 +1,76 @@
+﻿using AutoMapper;
+using FluentResults;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Streetcode.BLL.DTO.Streetcode.Comments;
+using Streetcode.BLL.Interfaces.Logging;
+using Streetcode.DAL.Entities.Streetcode.Comments;
+using Streetcode.DAL.Repositories.Interfaces.Base;
+using Streetcode.Resources;
+using Streetcode.Shared.Extensions;
+
+namespace Streetcode.BLL.MediatR.Streetcode.Comments.GetByIdWithReplies
+{
+    public class GetCommentByIdWithRepliesHandler : IRequestHandler<GetCommentByIdWithRepliesQuery, Result<CommentDTO>>
+    {
+        private readonly IMapper _mapper;
+        private readonly IRepositoryWrapper _repositoryWrapper;
+        private readonly ILoggerService _logger;
+
+        public GetCommentByIdWithRepliesHandler(IRepositoryWrapper repositoryWrapper, IMapper mapper, ILoggerService logger)
+        {
+            _repositoryWrapper = repositoryWrapper;
+            _mapper = mapper;
+            _logger = logger;
+        }
+
+        public async Task<Result<CommentDTO>> Handle(GetCommentByIdWithRepliesQuery request, CancellationToken cancellationToken)
+        {
+            var targetComment = await _repositoryWrapper.CommentRepository
+                .GetFirstOrDefaultAsync(c => c.Id == request.Id);
+
+            if (targetComment is null)
+            {
+                var errorNotFoundMsg = Messages.Error_EntityWithIdNotFound.Format(nameof(Comment), request.Id);
+                _logger.LogError(request, errorNotFoundMsg);
+                return Result.Fail(new Error(errorNotFoundMsg));
+            }
+
+            var allComments = await _repositoryWrapper.CommentRepository.GetAllAsync(
+                predicate: c => c.StreetcodeId == targetComment.StreetcodeId,
+                include: x => x.Include(c => c.User));
+
+            var dtos = _mapper.Map<IEnumerable<CommentDTO>>(allComments).ToList();
+            var dictionary = dtos.ToDictionary(x => x.Id);
+
+            foreach (var dto in dtos)
+            {
+                if (dto.ParentId.HasValue && dictionary.TryGetValue(dto.ParentId.Value, out var parent))
+                {
+                    parent.Replies.Add(dto);
+                }
+            }
+
+            var resultComment = dictionary[request.Id];
+
+            SortReplies(resultComment.Replies);
+
+            return Result.Ok(resultComment);
+        }
+
+        private static void SortReplies(List<CommentDTO> comments)
+        {
+            foreach (var comment in comments)
+            {
+                if (comment.Replies != null && comment.Replies.Any())
+                {
+                    comment.Replies = comment.Replies
+                        .OrderBy(c => c.CreatedAt)
+                        .ToList();
+
+                    SortReplies(comment.Replies);
+                }
+            }
+        }
+    }
+}

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Comments/GetByIdWithReplies/GetCommentByIdWithRepliesQuery.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Comments/GetByIdWithReplies/GetCommentByIdWithRepliesQuery.cs
@@ -1,0 +1,8 @@
+﻿using FluentResults;
+using MediatR;
+using Streetcode.BLL.DTO.Streetcode.Comments;
+
+namespace Streetcode.BLL.MediatR.Streetcode.Comments.GetByIdWithReplies
+{
+    public record GetCommentByIdWithRepliesQuery(int Id) : IRequest<Result<CommentDTO>>;
+}

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Comments/GetByStreetcodeId/GetCommentsByStreetcodeIdHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Comments/GetByStreetcodeId/GetCommentsByStreetcodeIdHandler.cs
@@ -4,6 +4,7 @@ using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Streetcode.BLL.DTO.Streetcode.Comments;
 using Streetcode.BLL.Interfaces.Logging;
+using Streetcode.DAL.Enums;
 using Streetcode.DAL.Repositories.Interfaces.Base;
 
 namespace Streetcode.BLL.MediatR.Streetcode.Comments.GetByStreetcodeId
@@ -24,12 +25,45 @@ namespace Streetcode.BLL.MediatR.Streetcode.Comments.GetByStreetcodeId
         public async Task<Result<IEnumerable<CommentDTO>>> Handle(GetCommentsByStreetcodeIdQuery request, CancellationToken cancellationToken)
         {
             var comments = await _repositoryWrapper.CommentRepository.GetAllAsync(
-                predicate: c => c.StreetcodeId == request.StreetcodeId,
+                predicate: c => c.StreetcodeId == request.StreetcodeId
+                             && c.Status == CommentStatus.Approved,
                 include: x => x.Include(c => c.User));
 
-            var sortedComments = comments.OrderByDescending(c => c.CreatedAt);
+            var dtos = _mapper.Map<IEnumerable<CommentDTO>>(comments).ToList();
 
-            return Result.Ok(_mapper.Map<IEnumerable<CommentDTO>>(sortedComments));
+            var dictionary = dtos.ToDictionary(x => x.Id);
+
+            foreach (var dto in dtos)
+            {
+                if (dto.ParentId.HasValue && dictionary.TryGetValue(dto.ParentId.Value, out var parent))
+                {
+                    parent.Replies.Add(dto);
+                }
+            }
+
+            var rootComments = dtos
+                .Where(c => c.ParentId == null)
+                .OrderByDescending(c => c.CreatedAt)
+                .ToList();
+
+            SortReplies(rootComments);
+
+            return Result.Ok((IEnumerable<CommentDTO>)rootComments);
+        }
+
+        private static void SortReplies(List<CommentDTO> comments)
+        {
+            foreach (var comment in comments)
+            {
+                if (comment.Replies != null && comment.Replies.Any())
+                {
+                    comment.Replies = comment.Replies
+                        .OrderBy(c => c.CreatedAt)
+                        .ToList();
+
+                    SortReplies(comment.Replies);
+                }
+            }
         }
     }
 }

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Comments/GetPending/GetPendingCommentsHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Comments/GetPending/GetPendingCommentsHandler.cs
@@ -1,0 +1,43 @@
+﻿using AutoMapper;
+using FluentResults;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Streetcode.BLL.DTO.Streetcode.Comments;
+using Streetcode.BLL.Interfaces.Logging;
+using Streetcode.DAL.Enums;
+using Streetcode.DAL.Repositories.Interfaces.Base;
+
+namespace Streetcode.BLL.MediatR.Streetcode.Comments.GetPending
+{
+    public class GetPendingCommentsHandler : IRequestHandler<GetPendingCommentsQuery, Result<IEnumerable<CommentDTO>>>
+    {
+        private readonly IMapper _mapper;
+        private readonly IRepositoryWrapper _repositoryWrapper;
+        private readonly ILoggerService _logger;
+
+        public GetPendingCommentsHandler(IRepositoryWrapper repositoryWrapper, IMapper mapper, ILoggerService logger)
+        {
+            _repositoryWrapper = repositoryWrapper;
+            _mapper = mapper;
+            _logger = logger;
+        }
+
+        public async Task<Result<IEnumerable<CommentDTO>>> Handle(GetPendingCommentsQuery request, CancellationToken cancellationToken)
+        {
+            var comments = await _repositoryWrapper.CommentRepository.GetAllAsync(
+                predicate: c => c.Status == CommentStatus.Pending,
+                include: x => x.Include(c => c.User));
+
+            if (!comments.Any())
+            {
+                return Result.Ok(Enumerable.Empty<CommentDTO>());
+            }
+
+            var sortedComments = comments.OrderBy(c => c.CreatedAt);
+
+            var dtos = _mapper.Map<IEnumerable<CommentDTO>>(sortedComments);
+
+            return Result.Ok(dtos);
+        }
+    }
+}

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Comments/GetPending/GetPendingCommentsQuery.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Comments/GetPending/GetPendingCommentsQuery.cs
@@ -1,0 +1,8 @@
+﻿using FluentResults;
+using MediatR;
+using Streetcode.BLL.DTO.Streetcode.Comments;
+
+namespace Streetcode.BLL.MediatR.Streetcode.Comments.GetPending
+{
+    public record GetPendingCommentsQuery() : IRequest<Result<IEnumerable<CommentDTO>>>;
+}

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Comments/Update/UpdateCommentHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Comments/Update/UpdateCommentHandler.cs
@@ -5,6 +5,7 @@ using Microsoft.EntityFrameworkCore;
 using Streetcode.BLL.DTO.Streetcode.Comments;
 using Streetcode.BLL.Interfaces.Logging;
 using Streetcode.DAL.Entities.Streetcode.Comments;
+using Streetcode.DAL.Enums;
 using Streetcode.DAL.Repositories.Interfaces.Base;
 using Streetcode.Resources;
 using Streetcode.Shared.Extensions;
@@ -49,6 +50,7 @@ namespace Streetcode.BLL.MediatR.Streetcode.Comments.Update
 
             comment = _mapper.Map(command.Comment, comment);
             comment.UpdatedAt = DateTime.UtcNow;
+            comment.Status = CommentStatus.Pending;
 
             _repositoryWrapper.CommentRepository.Update(comment);
             var successSave = await _repositoryWrapper.SaveChangesAsync() > 0;

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Comments/UpdateStatus/UpdateCommentStatusCommand.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Comments/UpdateStatus/UpdateCommentStatusCommand.cs
@@ -1,0 +1,8 @@
+﻿using FluentResults;
+using MediatR;
+using Streetcode.BLL.DTO.Streetcode.Comments;
+
+namespace Streetcode.BLL.MediatR.Streetcode.Comments.UpdateStatus
+{
+    public record UpdateCommentStatusCommand(UpdateCommentStatusDTO Comment) : IRequest<Result<CommentDTO>>;
+}

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Comments/UpdateStatus/UpdateCommentStatusCommandValidator.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Comments/UpdateStatus/UpdateCommentStatusCommandValidator.cs
@@ -1,0 +1,16 @@
+﻿using FluentValidation;
+using Streetcode.Resources;
+
+namespace Streetcode.BLL.MediatR.Streetcode.Comments.UpdateStatus
+{
+    public class UpdateCommentStatusCommandValidator : AbstractValidator<UpdateCommentStatusCommand>
+    {
+        public UpdateCommentStatusCommandValidator()
+        {
+            RuleFor(x => x.Comment)
+                .NotNull()
+                .WithMessage(Messages.Error_CommandDataRequired)
+                .SetValidator(new UpdateCommentStatusDTOValidator());
+        }
+    }
+}

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Comments/UpdateStatus/UpdateCommentStatusDTOValidator.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Comments/UpdateStatus/UpdateCommentStatusDTOValidator.cs
@@ -1,0 +1,21 @@
+﻿using FluentValidation;
+using Streetcode.BLL.DTO.Streetcode.Comments;
+using Streetcode.Resources;
+using Streetcode.Shared.Extensions;
+
+namespace Streetcode.BLL.MediatR.Streetcode.Comments.UpdateStatus
+{
+    public class UpdateCommentStatusDTOValidator : AbstractValidator<UpdateCommentStatusDTO>
+    {
+        public UpdateCommentStatusDTOValidator()
+        {
+            RuleFor(x => x.Id)
+                .GreaterThan(0)
+                .WithMessage(Messages.Error_PropertyMustBeGreaterThanZero.Format(nameof(UpdateCommentStatusDTO.Id)));
+
+            RuleFor(x => x.Status)
+                .IsInEnum()
+                .WithMessage(Messages.Error_InvalidEnumValue.Format(nameof(UpdateCommentStatusDTO.Status)));
+        }
+    }
+}

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Comments/UpdateStatus/UpdateCommentStatusHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Comments/UpdateStatus/UpdateCommentStatusHandler.cs
@@ -30,15 +30,12 @@ namespace Streetcode.BLL.MediatR.Streetcode.Comments.UpdateStatus
 
             if (comment is null)
             {
-                var errorNotFoundMsg = Messages.Error_EntityWithIdNotFound.Format(nameof(Comment), request.Dto.Id);
+                var errorNotFoundMsg = Messages.Error_EntityWithIdNotFound.Format(nameof(Comment), request.Comment.Id);
                 _logger.LogError(request, errorNotFoundMsg);
                 return Result.Fail(new Error(errorNotFoundMsg));
             }
 
-            // Оновлюємо статус
-            comment.Status = request.Dto.Status;
-
-            // Фіксуємо час, коли адмін перевірив коментар
+            comment.Status = request.Comment.Status;
             comment.UpdatedAt = DateTime.UtcNow;
 
             _repositoryWrapper.CommentRepository.Update(comment);

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Comments/UpdateStatus/UpdateCommentStatusHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Comments/UpdateStatus/UpdateCommentStatusHandler.cs
@@ -1,0 +1,57 @@
+﻿using AutoMapper;
+using FluentResults;
+using MediatR;
+using Streetcode.BLL.DTO.Streetcode.Comments;
+using Streetcode.BLL.Interfaces.Logging;
+using Streetcode.DAL.Entities.Streetcode.Comments;
+using Streetcode.DAL.Repositories.Interfaces.Base;
+using Streetcode.Resources;
+using Streetcode.Shared.Extensions;
+
+namespace Streetcode.BLL.MediatR.Streetcode.Comments.UpdateStatus
+{
+    public class UpdateCommentStatusHandler : IRequestHandler<UpdateCommentStatusCommand, Result<CommentDTO>>
+    {
+        private readonly IRepositoryWrapper _repositoryWrapper;
+        private readonly IMapper _mapper;
+        private readonly ILoggerService _logger;
+
+        public UpdateCommentStatusHandler(IRepositoryWrapper repositoryWrapper, IMapper mapper, ILoggerService logger)
+        {
+            _repositoryWrapper = repositoryWrapper;
+            _mapper = mapper;
+            _logger = logger;
+        }
+
+        public async Task<Result<CommentDTO>> Handle(UpdateCommentStatusCommand request, CancellationToken cancellationToken)
+        {
+            var comment = await _repositoryWrapper.CommentRepository
+                .GetFirstOrDefaultAsync(c => c.Id == request.Comment.Id);
+
+            if (comment is null)
+            {
+                var errorNotFoundMsg = Messages.Error_EntityWithIdNotFound.Format(nameof(Comment), request.Dto.Id);
+                _logger.LogError(request, errorNotFoundMsg);
+                return Result.Fail(new Error(errorNotFoundMsg));
+            }
+
+            // Оновлюємо статус
+            comment.Status = request.Dto.Status;
+
+            // Фіксуємо час, коли адмін перевірив коментар
+            comment.UpdatedAt = DateTime.UtcNow;
+
+            _repositoryWrapper.CommentRepository.Update(comment);
+            var successSave = await _repositoryWrapper.SaveChangesAsync() > 0;
+
+            if (successSave)
+            {
+                return Result.Ok(_mapper.Map<CommentDTO>(comment));
+            }
+
+            var errorMsg = Messages.Error_FailedToUpdateEntity.Format(nameof(Comment));
+            _logger.LogError(request, errorMsg);
+            return Result.Fail(new Error(errorMsg));
+        }
+    }
+}

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Comments/UpdateStatus/UpdateCommentStatusHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Comments/UpdateStatus/UpdateCommentStatusHandler.cs
@@ -36,7 +36,6 @@ namespace Streetcode.BLL.MediatR.Streetcode.Comments.UpdateStatus
             }
 
             comment.Status = request.Comment.Status;
-            comment.UpdatedAt = DateTime.UtcNow;
 
             _repositoryWrapper.CommentRepository.Update(comment);
             var successSave = await _repositoryWrapper.SaveChangesAsync() > 0;

--- a/Streetcode/Streetcode.DAL/Entities/Streetcode/Comments/Comment.cs
+++ b/Streetcode/Streetcode.DAL/Entities/Streetcode/Comments/Comment.cs
@@ -1,6 +1,7 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using Streetcode.DAL.Entities.Users;
+using Streetcode.DAL.Enums;
 
 namespace Streetcode.DAL.Entities.Streetcode.Comments
 {
@@ -29,5 +30,14 @@ namespace Streetcode.DAL.Entities.Streetcode.Comments
         public string UserId { get; set; }
 
         public User? User { get; set; }
+
+        public int? ParentId { get; set; }
+
+        public Comment? Parent { get; set; }
+
+        public List<Comment> Replies { get; set; } = new();
+
+        [Required]
+        public CommentStatus Status { get; set; } = CommentStatus.Pending;
     }
 }

--- a/Streetcode/Streetcode.DAL/Enums/CommentStatus.cs
+++ b/Streetcode/Streetcode.DAL/Enums/CommentStatus.cs
@@ -1,0 +1,9 @@
+﻿namespace Streetcode.DAL.Enums
+{
+    public enum CommentStatus
+    {
+        Pending,
+        Approved,
+        Rejected
+    }
+}

--- a/Streetcode/Streetcode.DAL/Persistence/Migrations/20260302074623_AddRepliesAndModerationToComments.Designer.cs
+++ b/Streetcode/Streetcode.DAL/Persistence/Migrations/20260302074623_AddRepliesAndModerationToComments.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Streetcode.DAL.Persistence;
 
@@ -11,9 +12,11 @@ using Streetcode.DAL.Persistence;
 namespace Streetcode.DAL.Persistence.Migrations
 {
     [DbContext(typeof(StreetcodeDbContext))]
-    partial class StreetcodeDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260302074623_AddRepliesAndModerationToComments")]
+    partial class AddRepliesAndModerationToComments
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Streetcode/Streetcode.DAL/Persistence/Migrations/20260302074623_AddRepliesAndModerationToComments.cs
+++ b/Streetcode/Streetcode.DAL/Persistence/Migrations/20260302074623_AddRepliesAndModerationToComments.cs
@@ -1,0 +1,68 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Streetcode.DAL.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRepliesAndModerationToComments : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "ParentId",
+                schema: "streetcode",
+                table: "comments",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "Status",
+                schema: "streetcode",
+                table: "comments",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_comments_ParentId",
+                schema: "streetcode",
+                table: "comments",
+                column: "ParentId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_comments_comments_ParentId",
+                schema: "streetcode",
+                table: "comments",
+                column: "ParentId",
+                principalSchema: "streetcode",
+                principalTable: "comments",
+                principalColumn: "Id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_comments_comments_ParentId",
+                schema: "streetcode",
+                table: "comments");
+
+            migrationBuilder.DropIndex(
+                name: "IX_comments_ParentId",
+                schema: "streetcode",
+                table: "comments");
+
+            migrationBuilder.DropColumn(
+                name: "ParentId",
+                schema: "streetcode",
+                table: "comments");
+
+            migrationBuilder.DropColumn(
+                name: "Status",
+                schema: "streetcode",
+                table: "comments");
+        }
+    }
+}

--- a/Streetcode/Streetcode.DAL/Persistence/Migrations/20260302182005_AddRepliesAndModerationToComments.Designer.cs
+++ b/Streetcode/Streetcode.DAL/Persistence/Migrations/20260302182005_AddRepliesAndModerationToComments.Designer.cs
@@ -12,7 +12,7 @@ using Streetcode.DAL.Persistence;
 namespace Streetcode.DAL.Persistence.Migrations
 {
     [DbContext(typeof(StreetcodeDbContext))]
-    [Migration("20260302074623_AddRepliesAndModerationToComments")]
+    [Migration("20260302182005_AddRepliesAndModerationToComments")]
     partial class AddRepliesAndModerationToComments
     {
         /// <inheritdoc />
@@ -1297,7 +1297,8 @@ namespace Streetcode.DAL.Persistence.Migrations
                 {
                     b.HasOne("Streetcode.DAL.Entities.Streetcode.Comments.Comment", "Parent")
                         .WithMany("Replies")
-                        .HasForeignKey("ParentId");
+                        .HasForeignKey("ParentId")
+                        .OnDelete(DeleteBehavior.Restrict);
 
                     b.HasOne("Streetcode.DAL.Entities.Streetcode.StreetcodeContent", "Streetcode")
                         .WithMany("Comments")

--- a/Streetcode/Streetcode.DAL/Persistence/Migrations/20260302182005_AddRepliesAndModerationToComments.cs
+++ b/Streetcode/Streetcode.DAL/Persistence/Migrations/20260302182005_AddRepliesAndModerationToComments.cs
@@ -38,7 +38,8 @@ namespace Streetcode.DAL.Persistence.Migrations
                 column: "ParentId",
                 principalSchema: "streetcode",
                 principalTable: "comments",
-                principalColumn: "Id");
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
         }
 
         /// <inheritdoc />

--- a/Streetcode/Streetcode.DAL/Persistence/Migrations/StreetcodeDbContextModelSnapshot.cs
+++ b/Streetcode/Streetcode.DAL/Persistence/Migrations/StreetcodeDbContextModelSnapshot.cs
@@ -1294,7 +1294,8 @@ namespace Streetcode.DAL.Persistence.Migrations
                 {
                     b.HasOne("Streetcode.DAL.Entities.Streetcode.Comments.Comment", "Parent")
                         .WithMany("Replies")
-                        .HasForeignKey("ParentId");
+                        .HasForeignKey("ParentId")
+                        .OnDelete(DeleteBehavior.Restrict);
 
                     b.HasOne("Streetcode.DAL.Entities.Streetcode.StreetcodeContent", "Streetcode")
                         .WithMany("Comments")

--- a/Streetcode/Streetcode.DAL/Persistence/StreetcodeDbContext.cs
+++ b/Streetcode/Streetcode.DAL/Persistence/StreetcodeDbContext.cs
@@ -316,9 +316,15 @@ public class StreetcodeDbContext : DbContext
             .HasValue<ToponymCoordinate>("coordinate_toponym");
 
         modelBuilder.Entity<User>()
-           .HasMany(d => d.Comments)
-           .WithOne(t => t.User)
-           .HasForeignKey(t => t.UserId)
-           .OnDelete(DeleteBehavior.Cascade);
+            .HasMany(d => d.Comments)
+            .WithOne(t => t.User)
+            .HasForeignKey(t => t.UserId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        modelBuilder.Entity<Comment>()
+            .HasOne(c => c.Parent)
+            .WithMany(c => c.Replies)
+            .HasForeignKey(c => c.ParentId)
+            .OnDelete(DeleteBehavior.Restrict);
     }
 }

--- a/Streetcode/Streetcode.Resources/Messages.Designer.cs
+++ b/Streetcode/Streetcode.Resources/Messages.Designer.cs
@@ -196,6 +196,15 @@ namespace Streetcode.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Invalid enum value for {0}.
+        /// </summary>
+        public static string Error_InvalidEnumValue {
+            get {
+                return ResourceManager.GetString("Error_InvalidEnumValue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Invalid Image format: {0}. Only {1} are allowed.
         /// </summary>
         public static string Error_InvalidImageFormat {

--- a/Streetcode/Streetcode.Resources/Messages.resx
+++ b/Streetcode/Streetcode.Resources/Messages.resx
@@ -216,4 +216,7 @@
   <data name="Error_RelatedTermsByTermIdNotFound" xml:space="preserve">
     <value>No RelatedTerm found by TermId: {0}</value>
   </data>
+  <data name="Error_InvalidEnumValue" xml:space="preserve">
+    <value>Invalid enum value for {0}</value>
+  </data>
 </root>

--- a/Streetcode/Streetcode.WebApi/Controllers/Streetcode/Comments/CommentController.cs
+++ b/Streetcode/Streetcode.WebApi/Controllers/Streetcode/Comments/CommentController.cs
@@ -5,8 +5,11 @@ using Streetcode.BLL.DTO.Streetcode.Comments;
 using Streetcode.BLL.MediatR.Streetcode.Comments.Create;
 using Streetcode.BLL.MediatR.Streetcode.Comments.Delete;
 using Streetcode.BLL.MediatR.Streetcode.Comments.GetByStreetcodeId;
+using Streetcode.BLL.MediatR.Streetcode.Comments.GetPending;
 using Streetcode.BLL.MediatR.Streetcode.Comments.Update;
+using Streetcode.BLL.MediatR.Streetcode.Comments.UpdateStatus;
 using Streetcode.Resources;
+using Streetcode.Shared.Enums;
 
 namespace Streetcode.WebApi.Controllers.Streetcode.Comments;
 
@@ -17,6 +20,13 @@ public class CommentController : BaseApiController
     public async Task<IActionResult> GetByStreetcodeId([FromRoute] int streetcodeId)
     {
         return HandleResult(await Mediator.Send(new GetCommentsByStreetcodeIdQuery(streetcodeId)));
+    }
+
+    [HttpGet("pending")]
+    [Authorize(Roles = nameof(UserRole.Administrator))]
+    public async Task<IActionResult> GetPendingComments()
+    {
+        return HandleResult(await Mediator.Send(new GetPendingCommentsQuery()));
     }
 
     [HttpPost]
@@ -45,6 +55,13 @@ public class CommentController : BaseApiController
         }
 
         return HandleResult(await Mediator.Send(new UpdateCommentCommand(updateCommentDTO, userId)));
+    }
+
+    [HttpPut("updateStatus")]
+    [Authorize(Roles = nameof(UserRole.Administrator))]
+    public async Task<IActionResult> UpdateStatus([FromBody] UpdateCommentStatusDTO dto)
+    {
+        return HandleResult(await Mediator.Send(new UpdateCommentStatusCommand(dto)));
     }
 
     [HttpDelete("{id:int}")]

--- a/Streetcode/Streetcode.WebApi/Controllers/Streetcode/Comments/CommentController.cs
+++ b/Streetcode/Streetcode.WebApi/Controllers/Streetcode/Comments/CommentController.cs
@@ -2,8 +2,10 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Streetcode.BLL.DTO.Streetcode.Comments;
+using Streetcode.BLL.MediatR.Streetcode.Comments.AdminDelete;
 using Streetcode.BLL.MediatR.Streetcode.Comments.Create;
 using Streetcode.BLL.MediatR.Streetcode.Comments.Delete;
+using Streetcode.BLL.MediatR.Streetcode.Comments.GetByIdWithReplies;
 using Streetcode.BLL.MediatR.Streetcode.Comments.GetByStreetcodeId;
 using Streetcode.BLL.MediatR.Streetcode.Comments.GetPending;
 using Streetcode.BLL.MediatR.Streetcode.Comments.Update;
@@ -27,6 +29,13 @@ public class CommentController : BaseApiController
     public async Task<IActionResult> GetPendingComments()
     {
         return HandleResult(await Mediator.Send(new GetPendingCommentsQuery()));
+    }
+
+    [HttpGet("withReplies/{id}")]
+    [Authorize(Roles = nameof(UserRole.Administrator))]
+    public async Task<IActionResult> GetCommentWithReplies([FromRoute] int id)
+    {
+        return HandleResult(await Mediator.Send(new GetCommentByIdWithRepliesQuery(id)));
     }
 
     [HttpPost]
@@ -76,6 +85,13 @@ public class CommentController : BaseApiController
         }
 
         return HandleResult(await Mediator.Send(new DeleteCommentCommand(id, userId)));
+    }
+
+    [HttpDelete("adminDelete/{id}")]
+    [Authorize(Roles = nameof(UserRole.Administrator))]
+    public async Task<IActionResult> AdminDeleteComment([FromRoute] int id)
+    {
+        return HandleResult(await Mediator.Send(new AdminDeleteCommentCommand(id)));
     }
 
     private string? GetCurrentUserId()

--- a/Streetcode/Streetcode.XUnitTest/MediatR/Comments/AdminDelete/AdminDeleteCommentCommandValidatorTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatR/Comments/AdminDelete/AdminDeleteCommentCommandValidatorTests.cs
@@ -1,0 +1,46 @@
+﻿namespace Streetcode.XUnitTest.MediatR.Comments.Delete
+{
+    using FluentValidation.TestHelper;
+    using Streetcode.BLL.MediatR.Streetcode.Comments.AdminDelete;
+    using Streetcode.Resources;
+    using Xunit;
+
+    public class AdminDeleteCommentCommandValidatorTests
+    {
+        private readonly AdminDeleteCommentCommandValidator validator;
+
+        public AdminDeleteCommentCommandValidatorTests()
+        {
+            this.validator = new AdminDeleteCommentCommandValidator();
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-1)]
+        public void ShouldHaveError_WhenIdIsInvalid(int id)
+        {
+            // Arrange
+            var command = new AdminDeleteCommentCommand(id);
+
+            // Act
+            var result = this.validator.TestValidate(command);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor(x => x.Id)
+                .WithErrorMessage(string.Format(Messages.Error_PropertyMustBeGreaterThanZero, nameof(AdminDeleteCommentCommand.Id)));
+        }
+
+        [Fact]
+        public void ShouldNotHaveError_WhenCommandIsValid()
+        {
+            // Arrange
+            var command = new AdminDeleteCommentCommand(10);
+
+            // Act
+            var result = this.validator.TestValidate(command);
+
+            // Assert
+            result.ShouldNotHaveAnyValidationErrors();
+        }
+    }
+}

--- a/Streetcode/Streetcode.XUnitTest/MediatR/Comments/AdminDelete/AdminDeleteCommentHandlerTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatR/Comments/AdminDelete/AdminDeleteCommentHandlerTests.cs
@@ -1,11 +1,11 @@
-﻿namespace Streetcode.XUnitTest.MediatR.Comments.Delete
+﻿namespace Streetcode.XUnitTest.MediatR.Comments.AdminDelete
 {
     using System.Linq.Expressions;
     using FluentAssertions;
     using global::MediatR;
     using Moq;
     using Streetcode.BLL.Interfaces.Logging;
-    using Streetcode.BLL.MediatR.Streetcode.Comments.Delete;
+    using Streetcode.BLL.MediatR.Streetcode.Comments.AdminDelete;
     using Streetcode.DAL.Entities.Streetcode.Comments;
     using Streetcode.DAL.Repositories.Interfaces.Base;
     using Streetcode.DAL.Repositories.Interfaces.Streetcode.Comments;
@@ -13,14 +13,14 @@
     using Streetcode.Shared.Extensions;
     using Xunit;
 
-    public class DeleteCommentHandlerTests
+    public class AdminDeleteCommentHandlerTests
     {
         private readonly Mock<IRepositoryWrapper> repositoryWrapperMock;
         private readonly Mock<ICommentRepository> commentRepositoryMock;
         private readonly Mock<ILoggerService> loggerMock;
-        private readonly DeleteCommentHandler handler;
+        private readonly AdminDeleteCommentHandler handler;
 
-        public DeleteCommentHandlerTests()
+        public AdminDeleteCommentHandlerTests()
         {
             this.repositoryWrapperMock = new Mock<IRepositoryWrapper>();
             this.commentRepositoryMock = new Mock<ICommentRepository>();
@@ -29,20 +29,19 @@
             this.repositoryWrapperMock.Setup(r => r.CommentRepository)
                 .Returns(this.commentRepositoryMock.Object);
 
-            this.handler = new DeleteCommentHandler(
+            this.handler = new AdminDeleteCommentHandler(
                 this.repositoryWrapperMock.Object,
                 this.loggerMock.Object);
         }
 
         [Fact]
-        public async Task Handle_ReturnsSuccess_WhenUserIsOwnerAndCommentExists()
+        public async Task Handle_ReturnsSuccess_WhenCommentExists()
         {
             // Arrange
             int commentId = 1;
-            string userId = "user-123";
-            var command = new DeleteCommentCommand(commentId, userId);
+            var command = new AdminDeleteCommentCommand(commentId);
 
-            var comment = new Comment { Id = commentId, UserId = userId };
+            var comment = new Comment { Id = commentId, StreetcodeId = 10 };
 
             this.commentRepositoryMock
                 .Setup(x => x.GetFirstOrDefaultAsync(
@@ -74,7 +73,7 @@
         public async Task Handle_ReturnsFail_WhenCommentNotFound()
         {
             // Arrange
-            var command = new DeleteCommentCommand(1, "user-123");
+            var command = new AdminDeleteCommentCommand(1);
 
             this.commentRepositoryMock
                 .Setup(x => x.GetFirstOrDefaultAsync(
@@ -96,41 +95,11 @@
         }
 
         [Fact]
-        public async Task Handle_ReturnsFail_WhenUserIsNotOwner()
-        {
-            // Arrange
-            int commentId = 1;
-            string ownerId = "owner";
-            string hackerId = "hacker";
-
-            var command = new DeleteCommentCommand(commentId, hackerId);
-            var comment = new Comment { Id = commentId, UserId = ownerId };
-
-            this.commentRepositoryMock
-                .Setup(x => x.GetFirstOrDefaultAsync(
-                    It.IsAny<Expression<Func<Comment, bool>>>(),
-                    null,
-                    It.IsAny<bool>()))
-                .ReturnsAsync(comment);
-
-            var expectedError = Messages.Error_UserNotCommentOwner;
-
-            // Act
-            var result = await this.handler.Handle(command, CancellationToken.None);
-
-            // Assert
-            result.IsFailed.Should().BeTrue();
-            result.Errors.First().Message.Should().Be(expectedError);
-
-            this.commentRepositoryMock.Verify(x => x.DeleteRange(It.IsAny<IEnumerable<Comment>>()), Times.Never);
-        }
-
-        [Fact]
         public async Task Handle_ReturnsFail_WhenSaveChangesFails()
         {
             // Arrange
-            var command = new DeleteCommentCommand(1, "user-123");
-            var comment = new Comment { Id = 1, UserId = "user-123" };
+            var command = new AdminDeleteCommentCommand(1);
+            var comment = new Comment { Id = 1, StreetcodeId = 10 };
 
             this.commentRepositoryMock
                 .Setup(x => x.GetFirstOrDefaultAsync(
@@ -165,14 +134,13 @@
         {
             // Arrange
             int targetCommentId = 1;
-            string userId = "user-123";
             int streetcodeId = 10;
-            var command = new DeleteCommentCommand(targetCommentId, userId);
+            var command = new AdminDeleteCommentCommand(targetCommentId);
 
-            var targetComment = new Comment { Id = targetCommentId, UserId = userId, StreetcodeId = streetcodeId };
-            var child1 = new Comment { Id = 2, UserId = userId, StreetcodeId = streetcodeId, ParentId = targetCommentId };
-            var child2 = new Comment { Id = 3, UserId = userId, StreetcodeId = streetcodeId, ParentId = targetCommentId };
-            var grandChild = new Comment { Id = 4, UserId = userId, StreetcodeId = streetcodeId, ParentId = 2 };
+            var targetComment = new Comment { Id = targetCommentId, StreetcodeId = streetcodeId };
+            var child1 = new Comment { Id = 2, StreetcodeId = streetcodeId, ParentId = targetCommentId };
+            var child2 = new Comment { Id = 3, StreetcodeId = streetcodeId, ParentId = targetCommentId };
+            var grandChild = new Comment { Id = 4, StreetcodeId = streetcodeId, ParentId = 2 };
 
             var allComments = new List<Comment> { targetComment, child1, child2, grandChild };
 

--- a/Streetcode/Streetcode.XUnitTest/MediatR/Comments/Controller/CommentControllerTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatR/Comments/Controller/CommentControllerTests.cs
@@ -8,10 +8,14 @@
     using Microsoft.AspNetCore.Mvc;
     using Moq;
     using Streetcode.BLL.DTO.Streetcode.Comments;
+    using Streetcode.BLL.MediatR.Streetcode.Comments.AdminDelete;
     using Streetcode.BLL.MediatR.Streetcode.Comments.Create;
     using Streetcode.BLL.MediatR.Streetcode.Comments.Delete;
+    using Streetcode.BLL.MediatR.Streetcode.Comments.GetByIdWithReplies;
     using Streetcode.BLL.MediatR.Streetcode.Comments.GetByStreetcodeId;
+    using Streetcode.BLL.MediatR.Streetcode.Comments.GetPending;
     using Streetcode.BLL.MediatR.Streetcode.Comments.Update;
+    using Streetcode.BLL.MediatR.Streetcode.Comments.UpdateStatus;
     using Streetcode.WebApi.Controllers.Streetcode.Comments;
     using Xunit;
 
@@ -173,6 +177,79 @@
             // Assert
             this.mediatorMock.Verify(
                 m => m.Send(It.Is<DeleteCommentCommand>(c => c.UserId == userId), default), Times.Once);
+            result.Should().BeAssignableTo<IActionResult>();
+        }
+
+        [Fact]
+        public async Task GetPendingComments_ShouldReturnOk_WhenSuccess()
+        {
+            // Arrange
+            var commentsList = new List<CommentDTO>
+            {
+                new () { Id = 1, TextContent = "Pending Test" },
+            };
+
+            this.mediatorMock.Setup(m => m.Send(It.IsAny<GetPendingCommentsQuery>(), default))
+                .ReturnsAsync(Result.Ok((IEnumerable<CommentDTO>)commentsList));
+
+            // Act
+            var result = await this.controller.GetPendingComments();
+
+            // Assert
+            this.mediatorMock.Verify(m => m.Send(It.IsAny<GetPendingCommentsQuery>(), default), Times.Once);
+            result.Should().BeAssignableTo<IActionResult>();
+        }
+
+        [Fact]
+        public async Task GetCommentWithReplies_ShouldReturnOk_WhenSuccess()
+        {
+            // Arrange
+            int commentId = 1;
+            var commentDto = new CommentDTO { Id = commentId, TextContent = "Tree Test" };
+
+            this.mediatorMock.Setup(m => m.Send(It.IsAny<GetCommentByIdWithRepliesQuery>(), default))
+                .ReturnsAsync(Result.Ok(commentDto));
+
+            // Act
+            var result = await this.controller.GetCommentWithReplies(commentId);
+
+            // Assert
+            this.mediatorMock.Verify(m => m.Send(It.Is<GetCommentByIdWithRepliesQuery>(q => q.Id == commentId), default), Times.Once);
+            result.Should().BeAssignableTo<IActionResult>();
+        }
+
+        [Fact]
+        public async Task UpdateStatus_ShouldReturnOk_WhenSuccess()
+        {
+            // Arrange
+            var dto = new UpdateCommentStatusDTO { Id = 1, Status = DAL.Enums.CommentStatus.Approved };
+            var returnedDto = new CommentDTO { Id = 1 };
+
+            this.mediatorMock.Setup(m => m.Send(It.IsAny<UpdateCommentStatusCommand>(), default))
+                .ReturnsAsync(Result.Ok(returnedDto));
+
+            // Act
+            var result = await this.controller.UpdateStatus(dto);
+
+            // Assert
+            this.mediatorMock.Verify(m => m.Send(It.Is<UpdateCommentStatusCommand>(c => c.Comment == dto), default), Times.Once);
+            result.Should().BeAssignableTo<IActionResult>();
+        }
+
+        [Fact]
+        public async Task AdminDeleteComment_ShouldReturnOk_WhenSuccess()
+        {
+            // Arrange
+            int commentId = 1;
+
+            this.mediatorMock.Setup(m => m.Send(It.IsAny<AdminDeleteCommentCommand>(), default))
+                .ReturnsAsync(Result.Ok(Unit.Value));
+
+            // Act
+            var result = await this.controller.AdminDeleteComment(commentId);
+
+            // Assert
+            this.mediatorMock.Verify(m => m.Send(It.Is<AdminDeleteCommentCommand>(c => c.Id == commentId), default), Times.Once);
             result.Should().BeAssignableTo<IActionResult>();
         }
     }

--- a/Streetcode/Streetcode.XUnitTest/MediatR/Comments/Create/CreateCommentHandlerTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatR/Comments/Create/CreateCommentHandlerTests.cs
@@ -128,6 +128,64 @@
         }
 
         [Fact]
+        public async Task Handle_ReturnsSuccess_WhenParentCommentExists()
+        {
+            // Arrange
+            var createDto = GetCreateCommentDTO();
+            createDto.ParentId = 5;
+            var userId = "user-123";
+            var command = new CreateCommentCommand(createDto, userId);
+
+            var parentComment = new Comment { Id = 5, StreetcodeId = createDto.StreetcodeId };
+
+            this.commentRepositoryMock
+                .Setup(x => x.GetFirstOrDefaultAsync(
+                    It.IsAny<Expression<Func<Comment, bool>>>(),
+                    null,
+                    It.IsAny<bool>()))
+                .ReturnsAsync(parentComment);
+
+            this.commentRepositoryMock.Setup(x => x.CreateAsync(It.IsAny<Comment>()))
+                .ReturnsAsync((Comment c) => c);
+
+            this.repositoryWrapperMock.Setup(x => x.SaveChangesAsync()).ReturnsAsync(1);
+
+            // Act
+            var result = await this.handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            result.IsSuccess.Should().BeTrue();
+            this.commentRepositoryMock.Verify(x => x.CreateAsync(It.IsAny<Comment>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task Handle_ReturnsFail_WhenParentCommentDoesNotExist()
+        {
+            // Arrange
+            var createDto = GetCreateCommentDTO();
+            createDto.ParentId = 999;
+            var userId = "user-123";
+            var command = new CreateCommentCommand(createDto, userId);
+
+            this.commentRepositoryMock
+                .Setup(x => x.GetFirstOrDefaultAsync(
+                    It.IsAny<Expression<Func<Comment, bool>>>(),
+                    null,
+                    It.IsAny<bool>()))
+                .ReturnsAsync((Comment?)null);
+
+            var expectedErrorMsg = Messages.Error_EntityWithIdNotFound.Format(nameof(Comment), createDto.ParentId);
+
+            // Act
+            var result = await this.handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            result.IsFailed.Should().BeTrue();
+            result.Errors.First().Message.Should().Be(expectedErrorMsg);
+            this.commentRepositoryMock.Verify(x => x.CreateAsync(It.IsAny<Comment>()), Times.Never);
+        }
+
+        [Fact]
         public async Task Handle_ReturnsFail_WhenSaveChangesFails()
         {
             // Arrange

--- a/Streetcode/Streetcode.XUnitTest/MediatR/Comments/Delete/DeleteCommentHandlerTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatR/Comments/Delete/DeleteCommentHandlerTests.cs
@@ -51,6 +51,13 @@
                     It.IsAny<bool>()))
                 .ReturnsAsync(comment);
 
+            this.commentRepositoryMock
+                .Setup(x => x.GetAllAsync(
+                    It.IsAny<Expression<Func<Comment, bool>>>(),
+                    null,
+                    It.IsAny<bool>()))
+                .ReturnsAsync(new List<Comment> { comment });
+
             this.repositoryWrapperMock.Setup(x => x.SaveChangesAsync()).ReturnsAsync(1);
 
             // Act
@@ -60,7 +67,7 @@
             result.IsSuccess.Should().BeTrue();
             result.Value.Should().Be(Unit.Value);
 
-            this.commentRepositoryMock.Verify(x => x.Delete(comment), Times.Once);
+            this.commentRepositoryMock.Verify(x => x.DeleteRange(It.IsAny<IEnumerable<Comment>>()), Times.Once);
         }
 
         [Fact]
@@ -85,7 +92,7 @@
             result.IsFailed.Should().BeTrue();
             result.Errors.First().Message.Should().Be(expectedError);
 
-            this.commentRepositoryMock.Verify(x => x.Delete(It.IsAny<Comment>()), Times.Never);
+            this.commentRepositoryMock.Verify(x => x.DeleteRange(It.IsAny<IEnumerable<Comment>>()), Times.Never);
         }
 
         [Fact]
@@ -115,7 +122,7 @@
             result.IsFailed.Should().BeTrue();
             result.Errors.First().Message.Should().Be(expectedError);
 
-            this.commentRepositoryMock.Verify(x => x.Delete(It.IsAny<Comment>()), Times.Never);
+            this.commentRepositoryMock.Verify(x => x.DeleteRange(It.IsAny<IEnumerable<Comment>>()), Times.Never);
         }
 
         [Fact]
@@ -132,6 +139,13 @@
                     It.IsAny<bool>()))
                 .ReturnsAsync(comment);
 
+            this.commentRepositoryMock
+                .Setup(x => x.GetAllAsync(
+                    It.IsAny<Expression<Func<Comment, bool>>>(),
+                    null,
+                    It.IsAny<bool>()))
+                .ReturnsAsync(new List<Comment> { comment });
+
             this.repositoryWrapperMock.Setup(x => x.SaveChangesAsync()).ReturnsAsync(0);
 
             var expectedError = Messages.Error_FailedToDeleteEntity.Format(nameof(Comment));
@@ -142,6 +156,56 @@
             // Assert
             result.IsFailed.Should().BeTrue();
             result.Errors.First().Message.Should().Be(expectedError);
+
+            this.commentRepositoryMock.Verify(x => x.DeleteRange(It.IsAny<IEnumerable<Comment>>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task Handle_ReturnsSuccess_AndDeletesAllDescendants_WhenCommentHasReplies()
+        {
+            // Arrange
+            int targetCommentId = 1;
+            string userId = "user-123";
+            int streetcodeId = 10;
+            var command = new DeleteCommentCommand(targetCommentId, userId);
+
+            var targetComment = new Comment { Id = targetCommentId, UserId = userId, StreetcodeId = streetcodeId };
+            var child1 = new Comment { Id = 2, UserId = userId, StreetcodeId = streetcodeId, ParentId = targetCommentId };
+            var child2 = new Comment { Id = 3, UserId = userId, StreetcodeId = streetcodeId, ParentId = targetCommentId };
+            var grandChild = new Comment { Id = 4, UserId = userId, StreetcodeId = streetcodeId, ParentId = 2 };
+
+            var allComments = new List<Comment> { targetComment, child1, child2, grandChild };
+
+            this.commentRepositoryMock
+                .Setup(x => x.GetFirstOrDefaultAsync(
+                    It.IsAny<Expression<Func<Comment, bool>>>(),
+                    null,
+                    It.IsAny<bool>()))
+                .ReturnsAsync(targetComment);
+
+            this.commentRepositoryMock
+                .Setup(x => x.GetAllAsync(
+                    It.IsAny<Expression<Func<Comment, bool>>>(),
+                    null,
+                    It.IsAny<bool>()))
+                .ReturnsAsync(allComments);
+
+            this.repositoryWrapperMock.Setup(x => x.SaveChangesAsync()).ReturnsAsync(1);
+
+            // Act
+            var result = await this.handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            result.IsSuccess.Should().BeTrue();
+
+            this.commentRepositoryMock.Verify(
+                x => x.DeleteRange(It.Is<IEnumerable<Comment>>(
+                    commentsToDelete =>
+                        commentsToDelete.Count() == 4 &&
+                        commentsToDelete.Contains(targetComment) &&
+                        commentsToDelete.Contains(child1) &&
+                        commentsToDelete.Contains(child2) &&
+                        commentsToDelete.Contains(grandChild))), Times.Once);
         }
     }
 }

--- a/Streetcode/Streetcode.XUnitTest/MediatR/Comments/GetByIdWithReplies/GetCommentByIdWithRepliesHandlerTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatR/Comments/GetByIdWithReplies/GetCommentByIdWithRepliesHandlerTests.cs
@@ -1,0 +1,185 @@
+﻿namespace Streetcode.XUnitTest.MediatR.Comments.GetByIdWithReplies
+{
+    using System.Linq.Expressions;
+    using AutoMapper;
+    using FluentAssertions;
+    using Microsoft.EntityFrameworkCore.Query;
+    using Moq;
+    using Streetcode.BLL.Interfaces.Logging;
+    using Streetcode.BLL.Mapping.Streetcode.Comments;
+    using Streetcode.BLL.MediatR.Streetcode.Comments.GetByIdWithReplies;
+    using Streetcode.DAL.Entities.Streetcode.Comments;
+    using Streetcode.DAL.Repositories.Interfaces.Base;
+    using Streetcode.DAL.Repositories.Interfaces.Streetcode.Comments;
+    using Streetcode.Resources;
+    using Streetcode.Shared.Extensions;
+    using Xunit;
+
+    public class GetCommentByIdWithRepliesHandlerTests
+    {
+        private readonly Mock<IRepositoryWrapper> repositoryWrapperMock;
+        private readonly Mock<ICommentRepository> commentRepositoryMock;
+        private readonly Mock<ILoggerService> loggerMock;
+        private readonly IMapper mapper;
+        private readonly GetCommentByIdWithRepliesHandler handler;
+
+        public GetCommentByIdWithRepliesHandlerTests()
+        {
+            this.repositoryWrapperMock = new Mock<IRepositoryWrapper>();
+            this.commentRepositoryMock = new Mock<ICommentRepository>();
+            this.loggerMock = new Mock<ILoggerService>();
+
+            this.repositoryWrapperMock.Setup(r => r.CommentRepository)
+                .Returns(this.commentRepositoryMock.Object);
+
+            var configuration = new MapperConfiguration(cfg =>
+            {
+                cfg.AddProfile(new CommentProfile());
+            });
+            this.mapper = new Mapper(configuration);
+
+            this.handler = new GetCommentByIdWithRepliesHandler(
+                this.repositoryWrapperMock.Object,
+                this.mapper,
+                this.loggerMock.Object);
+        }
+
+        [Fact]
+        public async Task Handle_ReturnsSuccess_WhenCommentExistsAndHasNoReplies()
+        {
+            // Arrange
+            int targetId = 1;
+            int streetcodeId = 10;
+            var query = new GetCommentByIdWithRepliesQuery(targetId);
+
+            var targetComment = new Comment { Id = targetId, StreetcodeId = streetcodeId, CreatedAt = DateTime.UtcNow };
+            var allComments = new List<Comment> { targetComment };
+
+            this.commentRepositoryMock
+                .Setup(x => x.GetFirstOrDefaultAsync(
+                    It.IsAny<Expression<Func<Comment, bool>>>(),
+                    null,
+                    It.IsAny<bool>()))
+                .ReturnsAsync(targetComment);
+
+            this.commentRepositoryMock
+                .Setup(x => x.GetAllAsync(
+                    It.IsAny<Expression<Func<Comment, bool>>>(),
+                    It.IsAny<Func<IQueryable<Comment>, IIncludableQueryable<Comment, object>>>(),
+                    It.IsAny<bool>()))
+                .ReturnsAsync(allComments);
+
+            // Act
+            var result = await this.handler.Handle(query, CancellationToken.None);
+
+            // Assert
+            result.IsSuccess.Should().BeTrue();
+            result.Value.Should().NotBeNull();
+
+            result.Value.Id.Should().Be(targetId);
+            result.Value.Replies.Should().BeEmpty();
+        }
+
+        [Fact]
+        public async Task Handle_BuildsTreeAndSortsReplies_WhenCommentHasReplies()
+        {
+            // Arrange
+            int targetId = 1;
+            int streetcodeId = 10;
+            var query = new GetCommentByIdWithRepliesQuery(targetId);
+            var baseTime = DateTime.UtcNow;
+
+            var targetComment = new Comment
+            {
+                Id = targetId,
+                StreetcodeId = streetcodeId,
+                CreatedAt = baseTime,
+            };
+            var child1 = new Comment
+            {
+                Id = 2,
+                StreetcodeId = streetcodeId,
+                ParentId = targetId,
+                CreatedAt = baseTime.AddMinutes(10),
+            };
+            var child2 = new Comment
+            {
+                Id = 3,
+                StreetcodeId = streetcodeId,
+                ParentId = targetId,
+                CreatedAt = baseTime.AddMinutes(5),
+            };
+            var grandChild = new Comment
+            {
+                Id = 4,
+                StreetcodeId = streetcodeId,
+                ParentId = 3,
+                CreatedAt = baseTime.AddMinutes(15),
+            };
+            var otherComment = new Comment
+            {
+                Id = 5,
+                StreetcodeId = streetcodeId,
+            };
+
+            var allComments = new List<Comment> { targetComment, child1, child2, grandChild, otherComment };
+
+            this.commentRepositoryMock
+                .Setup(x => x.GetFirstOrDefaultAsync(
+                    It.IsAny<Expression<Func<Comment, bool>>>(),
+                    null,
+                    It.IsAny<bool>()))
+                .ReturnsAsync(targetComment);
+
+            this.commentRepositoryMock
+                .Setup(x => x.GetAllAsync(
+                    It.IsAny<Expression<Func<Comment, bool>>>(),
+                    It.IsAny<Func<IQueryable<Comment>, IIncludableQueryable<Comment, object>>>(),
+                    It.IsAny<bool>()))
+                .ReturnsAsync(allComments);
+
+            // Act
+            var result = await this.handler.Handle(query, CancellationToken.None);
+
+            // Assert
+            result.IsSuccess.Should().BeTrue();
+            result.Value.Should().NotBeNull();
+
+            var resultComment = result.Value;
+            resultComment.Id.Should().Be(targetId);
+            resultComment.Replies.Should().HaveCount(2);
+
+            resultComment.Replies[0].Id.Should().Be(3);
+            resultComment.Replies[1].Id.Should().Be(2);
+
+            resultComment.Replies[0].Replies.Should().HaveCount(1);
+            resultComment.Replies[0].Replies[0].Id.Should().Be(4);
+
+            resultComment.Replies[1].Replies.Should().BeEmpty();
+        }
+
+        [Fact]
+        public async Task Handle_ReturnsFail_WhenCommentNotFound()
+        {
+            // Arrange
+            var query = new GetCommentByIdWithRepliesQuery(99);
+
+            this.commentRepositoryMock
+                .Setup(x => x.GetFirstOrDefaultAsync(
+                    It.IsAny<Expression<Func<Comment, bool>>>(),
+                    null,
+                    It.IsAny<bool>()))
+                .ReturnsAsync((Comment?)null);
+
+            var expectedError = Messages.Error_EntityWithIdNotFound.Format(nameof(Comment), query.Id);
+
+            // Act
+            var result = await this.handler.Handle(query, CancellationToken.None);
+
+            // Assert
+            result.IsFailed.Should().BeTrue();
+            result.Errors.First().Message.Should().Be(expectedError);
+        }
+
+    }
+}

--- a/Streetcode/Streetcode.XUnitTest/MediatR/Comments/GetByStreetcodeId/GetCommentsByStreetcodeIdHandlerTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatR/Comments/GetByStreetcodeId/GetCommentsByStreetcodeIdHandlerTests.cs
@@ -1,6 +1,5 @@
 ﻿namespace Streetcode.XUnitTest.MediatR.Comments.GetByStreetcodeId
 {
-    using System.Linq.Expressions;
     using AutoMapper;
     using FluentAssertions;
     using Microsoft.EntityFrameworkCore.Query;
@@ -9,8 +8,10 @@
     using Streetcode.BLL.Mapping.Streetcode.Comments;
     using Streetcode.BLL.MediatR.Streetcode.Comments.GetByStreetcodeId;
     using Streetcode.DAL.Entities.Streetcode.Comments;
+    using Streetcode.DAL.Enums;
     using Streetcode.DAL.Repositories.Interfaces.Base;
     using Streetcode.DAL.Repositories.Interfaces.Streetcode.Comments;
+    using System.Linq.Expressions;
     using Xunit;
 
     public class GetCommentsByStreetcodeIdHandlerTests
@@ -108,6 +109,78 @@
             result.IsSuccess.Should().BeTrue();
             result.Value.Should().NotBeNull();
             result.Value.Should().BeEmpty();
+        }
+
+        [Fact]
+        public async Task Handle_BuildsTreeAndSortsRepliesCorrectly_WhenCommentsHaveHierarchy()
+        {
+            // Arrange
+            int streetcodeId = 1;
+            var query = new GetCommentsByStreetcodeIdQuery(streetcodeId);
+            var baseTime = DateTime.UtcNow;
+
+            var comments = new List<Comment>
+            {
+                new ()
+                {
+                    Id = 1,
+                    StreetcodeId = streetcodeId,
+                    ParentId = null,
+                    CreatedAt = baseTime,
+                    Status = CommentStatus.Approved,
+                },
+                new ()
+                {
+                    Id = 2,
+                    StreetcodeId = streetcodeId,
+                    ParentId = 1,
+                    CreatedAt = baseTime.AddMinutes(10),
+                    Status = CommentStatus.Approved,
+                },
+                new ()
+                {
+                    Id = 3,
+                    StreetcodeId = streetcodeId,
+                    ParentId = 1,
+                    CreatedAt = baseTime.AddMinutes(5),
+                    Status = CommentStatus.Approved,
+                },
+                new ()
+                {
+                    Id = 4,
+                    StreetcodeId = streetcodeId,
+                    ParentId = 3,
+                    CreatedAt = baseTime.AddMinutes(15),
+                    Status = CommentStatus.Approved,
+                },
+            };
+
+            this.commentRepositoryMock
+                .Setup(x => x.GetAllAsync(
+                    It.IsAny<Expression<Func<Comment, bool>>>(),
+                    It.IsAny<Func<IQueryable<Comment>, IIncludableQueryable<Comment, object>>>(),
+                    It.IsAny<bool>()))
+                .ReturnsAsync(comments);
+
+            // Act
+            var result = await this.handler.Handle(query, CancellationToken.None);
+
+            // Assert
+            result.IsSuccess.Should().BeTrue();
+            var rootComments = result.Value.ToList();
+
+            rootComments.Should().HaveCount(1);
+            var root = rootComments[0];
+            root.Id.Should().Be(1);
+
+            root.Replies.Should().HaveCount(2);
+            root.Replies[0].Id.Should().Be(3);
+            root.Replies[1].Id.Should().Be(2);
+
+            root.Replies[0].Replies.Should().HaveCount(1);
+            root.Replies[0].Replies[0].Id.Should().Be(4);
+
+            root.Replies[1].Replies.Should().BeEmpty();
         }
     }
 }

--- a/Streetcode/Streetcode.XUnitTest/MediatR/Comments/GetPending/GetPendingCommentsHandlerTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatR/Comments/GetPending/GetPendingCommentsHandlerTests.cs
@@ -1,0 +1,120 @@
+﻿namespace Streetcode.XUnitTest.MediatR.Comments.GetPending
+{
+    using System.Linq.Expressions;
+    using AutoMapper;
+    using FluentAssertions;
+    using Microsoft.EntityFrameworkCore.Query;
+    using Moq;
+    using Streetcode.BLL.Interfaces.Logging;
+    using Streetcode.BLL.Mapping.Streetcode.Comments;
+    using Streetcode.BLL.MediatR.Streetcode.Comments.GetPending;
+    using Streetcode.DAL.Entities.Streetcode.Comments;
+    using Streetcode.DAL.Enums;
+    using Streetcode.DAL.Repositories.Interfaces.Base;
+    using Streetcode.DAL.Repositories.Interfaces.Streetcode.Comments;
+    using Xunit;
+
+    public class GetPendingCommentsHandlerTests
+    {
+        private readonly Mock<IRepositoryWrapper> repositoryWrapperMock;
+        private readonly Mock<ICommentRepository> commentRepositoryMock;
+        private readonly Mock<ILoggerService> loggerMock;
+        private readonly IMapper mapper;
+        private readonly GetPendingCommentsHandler handler;
+
+        public GetPendingCommentsHandlerTests()
+        {
+            this.repositoryWrapperMock = new Mock<IRepositoryWrapper>();
+            this.commentRepositoryMock = new Mock<ICommentRepository>();
+            this.loggerMock = new Mock<ILoggerService>();
+
+            this.repositoryWrapperMock.Setup(r => r.CommentRepository)
+                .Returns(this.commentRepositoryMock.Object);
+
+            var configuration = new MapperConfiguration(cfg =>
+            {
+                cfg.AddProfile(new CommentProfile());
+            });
+            this.mapper = new Mapper(configuration);
+
+            this.handler = new GetPendingCommentsHandler(
+                this.repositoryWrapperMock.Object,
+                this.mapper,
+                this.loggerMock.Object);
+        }
+
+        [Fact]
+        public async Task Handle_ReturnsSortedComments_WhenPendingCommentsExist()
+        {
+            // Arrange
+            var query = new GetPendingCommentsQuery();
+            var baseTime = DateTime.UtcNow;
+
+            var comments = new List<Comment>
+            {
+                new ()
+                {
+                    Id = 1,
+                    CreatedAt = baseTime.AddDays(-1),
+                    Status = CommentStatus.Pending,
+                    TextContent = "Middle",
+                },
+                new ()
+                {
+                    Id = 2,
+                    CreatedAt = baseTime,
+                    Status = CommentStatus.Pending,
+                    TextContent = "Newest",
+                },
+                new ()
+                {
+                    Id = 3,
+                    CreatedAt = baseTime.AddDays(-2),
+                    Status = CommentStatus.Pending,
+                    TextContent = "Oldest",
+                },
+            };
+
+            this.commentRepositoryMock
+                .Setup(x => x.GetAllAsync(
+                    It.IsAny<Expression<Func<Comment, bool>>>(),
+                    It.IsAny<Func<IQueryable<Comment>, IIncludableQueryable<Comment, object>>>(),
+                    It.IsAny<bool>()))
+                .ReturnsAsync(comments);
+
+            // Act
+            var result = await this.handler.Handle(query, CancellationToken.None);
+
+            // Assert
+            result.IsSuccess.Should().BeTrue();
+            result.Value.Should().HaveCount(3);
+
+            var resultList = result.Value.ToList();
+            resultList[0].TextContent.Should().Be("Oldest");
+            resultList[1].TextContent.Should().Be("Middle");
+            resultList[2].TextContent.Should().Be("Newest");
+        }
+
+        [Fact]
+        public async Task Handle_ReturnsEmptyList_WhenNoPendingCommentsFound()
+        {
+            // Arrange
+            var query = new GetPendingCommentsQuery();
+
+            this.commentRepositoryMock
+                .Setup(x => x.GetAllAsync(
+                    It.IsAny<Expression<Func<Comment, bool>>>(),
+                    It.IsAny<Func<IQueryable<Comment>, IIncludableQueryable<Comment, object>>>(),
+                    It.IsAny<bool>()))
+                .ReturnsAsync(new List<Comment>());
+
+            // Act
+            var result = await this.handler.Handle(query, CancellationToken.None);
+
+            // Assert
+            result.IsSuccess.Should().BeTrue();
+            result.Value.Should().NotBeNull();
+            result.Value.Should().BeEmpty();
+        }
+    }
+}

--- a/Streetcode/Streetcode.XUnitTest/MediatR/Comments/UpdateStatus/UpdateCommentStatusCommandValidatorTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatR/Comments/UpdateStatus/UpdateCommentStatusCommandValidatorTests.cs
@@ -1,0 +1,61 @@
+﻿namespace Streetcode.XUnitTest.MediatR.Comments.UpdateStatus
+{
+    using FluentValidation.TestHelper;
+    using Streetcode.BLL.DTO.Streetcode.Comments;
+    using Streetcode.BLL.MediatR.Streetcode.Comments.UpdateStatus;
+    using Streetcode.DAL.Enums;
+    using Streetcode.Resources;
+    using Xunit;
+
+    public class UpdateCommentStatusCommandValidatorTests
+    {
+        private readonly UpdateCommentStatusCommandValidator validator;
+
+        public UpdateCommentStatusCommandValidatorTests()
+        {
+            this.validator = new UpdateCommentStatusCommandValidator();
+        }
+
+        [Fact]
+        public void ShouldHaveError_WhenDtoIsNull()
+        {
+            // Arrange
+            var command = new UpdateCommentStatusCommand(null!);
+
+            // Act
+            var result = this.validator.TestValidate(command);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor(x => x.Comment)
+                .WithErrorMessage(Messages.Error_CommandDataRequired);
+        }
+
+        [Fact]
+        public void ShouldHaveError_WhenChildDtoIsInvalid()
+        {
+            // Arrange
+            var invalidDto = new UpdateCommentStatusDTO { Id = 0, Status = CommentStatus.Approved };
+            var command = new UpdateCommentStatusCommand(invalidDto);
+
+            // Act
+            var result = this.validator.TestValidate(command);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor("Comment.Id");
+        }
+
+        [Fact]
+        public void ShouldNotHaveError_WhenCommandIsValid()
+        {
+            // Arrange
+            var validDto = new UpdateCommentStatusDTO { Id = 1, Status = CommentStatus.Approved };
+            var command = new UpdateCommentStatusCommand(validDto);
+
+            // Act
+            var result = this.validator.TestValidate(command);
+
+            // Assert
+            result.ShouldNotHaveAnyValidationErrors();
+        }
+    }
+}

--- a/Streetcode/Streetcode.XUnitTest/MediatR/Comments/UpdateStatus/UpdateCommentStatusDTOValidatorTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatR/Comments/UpdateStatus/UpdateCommentStatusDTOValidatorTests.cs
@@ -1,0 +1,69 @@
+﻿namespace Streetcode.XUnitTest.MediatR.Comments.UpdateStatus
+{
+    using FluentValidation.TestHelper;
+    using Streetcode.BLL.DTO.Streetcode.Comments;
+    using Streetcode.BLL.MediatR.Streetcode.Comments.UpdateStatus;
+    using Streetcode.DAL.Enums;
+    using Streetcode.Resources;
+    using Streetcode.Shared.Extensions;
+    using Xunit;
+
+    public class UpdateCommentStatusDTOValidatorTests
+    {
+        private readonly UpdateCommentStatusDTOValidator validator;
+
+        public UpdateCommentStatusDTOValidatorTests()
+        {
+            this.validator = new UpdateCommentStatusDTOValidator();
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-1)]
+        public void ShouldHaveError_WhenIdIsInvalid(int id)
+        {
+            // Arrange
+            var model = new UpdateCommentStatusDTO { Id = id, Status = CommentStatus.Approved };
+
+            // Act
+            var result = this.validator.TestValidate(model);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor(x => x.Id)
+                .WithErrorMessage(string.Format(Messages.Error_PropertyMustBeGreaterThanZero, nameof(UpdateCommentStatusDTO.Id)));
+        }
+
+        [Theory]
+        [InlineData((CommentStatus)999)]
+        [InlineData((CommentStatus)(-1))]
+        public void ShouldHaveError_WhenStatusIsInvalid(CommentStatus status)
+        {
+            // Arrange
+            var model = new UpdateCommentStatusDTO { Id = 1, Status = status };
+
+            // Act
+            var result = this.validator.TestValidate(model);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor(x => x.Status)
+                .WithErrorMessage(Messages.Error_InvalidEnumValue.Format(nameof(UpdateCommentStatusDTO.Status)));
+        }
+
+        [Fact]
+        public void ShouldNotHaveError_WhenDtoIsValid()
+        {
+            // Arrange
+            var model = new UpdateCommentStatusDTO
+            {
+                Id = 1,
+                Status = CommentStatus.Approved,
+            };
+
+            // Act
+            var result = this.validator.TestValidate(model);
+
+            // Assert
+            result.ShouldNotHaveAnyValidationErrors();
+        }
+    }
+}

--- a/Streetcode/Streetcode.XUnitTest/MediatR/Comments/UpdateStatus/UpdateCommentStatusHandlerTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatR/Comments/UpdateStatus/UpdateCommentStatusHandlerTests.cs
@@ -1,0 +1,136 @@
+﻿namespace Streetcode.XUnitTest.MediatR.Comments.UpdateStatus
+{
+    using System.Linq.Expressions;
+    using AutoMapper;
+    using FluentAssertions;
+    using Moq;
+    using Streetcode.BLL.DTO.Streetcode.Comments;
+    using Streetcode.BLL.Interfaces.Logging;
+    using Streetcode.BLL.Mapping.Streetcode.Comments;
+    using Streetcode.BLL.MediatR.Streetcode.Comments.UpdateStatus;
+    using Streetcode.DAL.Entities.Streetcode.Comments;
+    using Streetcode.DAL.Enums;
+    using Streetcode.DAL.Repositories.Interfaces.Base;
+    using Streetcode.DAL.Repositories.Interfaces.Streetcode.Comments;
+    using Streetcode.Resources;
+    using Streetcode.Shared.Extensions;
+    using Xunit;
+
+    public class UpdateCommentStatusHandlerTests
+    {
+        private readonly Mock<IRepositoryWrapper> repositoryWrapperMock;
+        private readonly Mock<ICommentRepository> commentRepositoryMock;
+        private readonly Mock<ILoggerService> loggerMock;
+        private readonly IMapper mapper;
+        private readonly UpdateCommentStatusHandler handler;
+
+        public UpdateCommentStatusHandlerTests()
+        {
+            this.repositoryWrapperMock = new Mock<IRepositoryWrapper>();
+            this.commentRepositoryMock = new Mock<ICommentRepository>();
+            this.loggerMock = new Mock<ILoggerService>();
+
+            this.repositoryWrapperMock.Setup(r => r.CommentRepository)
+                .Returns(this.commentRepositoryMock.Object);
+
+            var configuration = new MapperConfiguration(cfg =>
+            {
+                cfg.AddProfile(new CommentProfile());
+            });
+            this.mapper = new Mapper(configuration);
+
+            this.handler = new UpdateCommentStatusHandler(
+                this.repositoryWrapperMock.Object,
+                this.mapper,
+                this.loggerMock.Object);
+        }
+
+        [Fact]
+        public async Task Handle_ReturnsSuccess_WhenCommentExistsAndSaved()
+        {
+            // Arrange
+            var dto = new UpdateCommentStatusDTO { Id = 1, Status = CommentStatus.Approved };
+            var command = new UpdateCommentStatusCommand(dto);
+
+            var existingComment = new Comment { Id = 1, Status = CommentStatus.Pending };
+
+            this.commentRepositoryMock
+                .Setup(x => x.GetFirstOrDefaultAsync(
+                    It.IsAny<Expression<Func<Comment, bool>>>(),
+                    null,
+                    It.IsAny<bool>()))
+                .ReturnsAsync(existingComment);
+
+            this.repositoryWrapperMock.Setup(x => x.SaveChangesAsync()).ReturnsAsync(1);
+
+            // Act
+            var result = await this.handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            result.IsSuccess.Should().BeTrue();
+            result.Value.Should().NotBeNull();
+            result.Value.Id.Should().Be(existingComment.Id);
+
+            existingComment.Status.Should().Be(CommentStatus.Approved);
+
+            this.commentRepositoryMock.Verify(x => x.Update(existingComment), Times.Once);
+        }
+
+        [Fact]
+        public async Task Handle_ReturnsFail_WhenCommentNotFound()
+        {
+            // Arrange
+            var dto = new UpdateCommentStatusDTO { Id = 99, Status = CommentStatus.Rejected };
+            var command = new UpdateCommentStatusCommand(dto);
+
+            this.commentRepositoryMock
+                .Setup(x => x.GetFirstOrDefaultAsync(
+                    It.IsAny<Expression<Func<Comment, bool>>>(),
+                    null,
+                    It.IsAny<bool>()))
+                .ReturnsAsync((Comment?)null);
+
+            var expectedError = Messages.Error_EntityWithIdNotFound.Format(nameof(Comment), dto.Id);
+
+            // Act
+            var result = await this.handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            result.IsFailed.Should().BeTrue();
+            result.Errors.First().Message.Should().Be(expectedError);
+
+            this.commentRepositoryMock.Verify(x => x.Update(It.IsAny<Comment>()), Times.Never);
+            this.repositoryWrapperMock.Verify(x => x.SaveChangesAsync(), Times.Never);
+        }
+
+        [Fact]
+        public async Task Handle_ReturnsFail_WhenSaveChangesFails()
+        {
+            // Arrange
+            var dto = new UpdateCommentStatusDTO { Id = 1, Status = CommentStatus.Approved };
+            var command = new UpdateCommentStatusCommand(dto);
+
+            var existingComment = new Comment { Id = 1, Status = CommentStatus.Pending };
+
+            this.commentRepositoryMock
+                .Setup(x => x.GetFirstOrDefaultAsync(
+                    It.IsAny<Expression<Func<Comment, bool>>>(),
+                    null,
+                    It.IsAny<bool>()))
+                .ReturnsAsync(existingComment);
+
+            this.repositoryWrapperMock.Setup(x => x.SaveChangesAsync()).ReturnsAsync(0);
+
+            var expectedError = Messages.Error_FailedToUpdateEntity.Format(nameof(Comment));
+
+            // Act
+            var result = await this.handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            result.IsFailed.Should().BeTrue();
+            result.Errors.First().Message.Should().Be(expectedError);
+
+            this.commentRepositoryMock.Verify(x => x.Update(existingComment), Times.Once);
+        }
+    }
+}


### PR DESCRIPTION
dev
## Code reviewers

- [x] @Darsicl 
- [ ] @Sohatzk 
- [ ] @DrFaust555 

## Summary of issue

The comment system lacked support for nested discussions (replies to comments) and required a moderation flow. Administrators needed the ability to review pending comments, understand their context within a thread, update their approval statuses, and forcefully remove inappropriate content.

## Summary of change

Implemented nested comment replies and a complete administrative moderation suite.
Key changes:
- Replies implementation: added logic to build hierarchical comment trees in memory, allowing users to see comments with their nested replies sorted by date.
- Admin endpoints (CommentController):
  - GET /pending: gets a flat list of all comments awaiting moderation (CommentStatus.Pending), sorted from oldest to newest.
  - GET /withReplies/{id}: fetches a specific comment and its entire nested reply tree to provide context for moderation (ignores status filters).
  - PUT /updateStatus: allows admins to change a comment status (to Approved or Rejected).
  - DELETE /adminDelete/{id}: enables admins to delete any comment and its cascade of replies without ownership checks.
- Created corresponding commands, queries, handlers, and DTOs.
- Testing: added unit tests for all new handlers, validators, and the controller, covering tree building, sorting, and cascade deletion.

## Tasks

- Closes #109 
- Closes #110 
- Closes #111 
- Closes #117  
- Closes #118 
- Closes #119 

## CHECK LIST
- [x]  СI passed
- [x]  Сode coverage >=80%
- [ ]  All reviewers agreed to merge the PR
- [x]  I've checked new feature as logged in and logged out user if needed
- [x]  PR meets all conventions
